### PR TITLE
adding a unit test + acks

### DIFF
--- a/ch2/test/ch2/core_test.clj
+++ b/ch2/test/ch2/core_test.clj
@@ -1,7 +1,16 @@
 (ns ch2.core-test
   (:require [clojure.test :refer :all]
-            [ch2.core :refer :all]))
+            [ch2.core :refer :all]
+            [org.apache.storm.testing :as st]))
 
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))
+(deftest test-topology
+  (st/with-simulated-time-local-cluster [cluster]
+    (let [result (st/complete-topology cluster
+                                       (github-commit-count-topology)
+                                       :mock-sources
+                                       {"1" [["aaaa foo@bar.com"]
+                                             ["bbbb bar@bar.com"]
+                                             ["cccc foo@bar.com"]]})]
+      (testing "Email Extractor"
+        (is (st/ms= [["foo@bar.com"] ["foo@bar.com"] ["bar@bar.com"]]
+                    (st/read-tuples result "2")))))))


### PR DESCRIPTION
Resolves #1.

Added a unit test to ch2 based on [this blogpost](http://www.pixelmachine.org/2011/12/17/Testing-Storm-Topologies.html).

Since this did not work right out of the box, I had to add `ack!` calls in the bolts.

I know this diverges from the original idea of this repo -- being an implementation of the examples in the Storm Applied book.  However, I think this completes this a bit and gives a slightly better starting point for programmers.